### PR TITLE
build: set default window size

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -25,6 +25,7 @@ function init(meta) { }
 function fillPreferencesWindow(window) {
     const themeSettings = ThemeSettings.getNewSchema();
     const builder = new Gtk.Builder();
+    window.set_default_size(360, 206);
 
     // Get themes
     const themes = Array.from([


### PR DESCRIPTION
Currently, the window is too large for few options. Having a smaller window is more visually pleasing.
![image](https://github.com/CharlieQLe/gnome-extension-gtk3-theme-switcher/assets/54215258/922619e1-b33a-4fb8-912b-3173befcebb2)
